### PR TITLE
setup.sh refactored to accept named arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,21 +58,23 @@ For Codespaces:
 The script `setup.sh` configures the environment to use Rust version `1.74.0` by default. If you need to use a different Rust version for your project, you can easily specify this by running the setup script with the desired version number as an argument. For example, to set up Rust version `1.55.0`, you would use the following command:
 
 ```bash
-./setup.sh 1.55.0
+./setup.sh --rust 1.55.0
 ```
 ### Python Version Configuration
 
 Similarly, the script is set up to configure the environment to use Python version `3.10` by default. If your project requires a different Python version, you can specify this by providing it as the second argument to the setup script. For instance, to set up Python version `3.9`, along with the default Rust version, you would run:
 
 ```bash
-./setup.sh 1.74.0 3.9
+./setup.sh --python 3.9
 ```
-Or, if you want to set up Python 3.9 with Rust 1.55.0, the command would be:
+### Specifying Both Versions
+
+If you need to specify both Rust and Python versions, you can provide both `--rust` and `--python` flags with their respective version numbers. For example, to set up Rust version `1.55.0` and Python version `3.9`, the command would be:
 
 ```bash
-./setup.sh 1.55.0 3.9
+./setup.sh --rust 1.55.0 --python 3.9
 ```
-These configurations allow for flexible environment setup to match the specific requirements of your project.
+These named argument configurations provide a clear and flexible way to set up your environment according to the specific requirements of your project.
 
 ## Features
 

--- a/setup.sh
+++ b/setup.sh
@@ -3,11 +3,32 @@
 # Stop execution if any command fails
 set -e
 
-# Rust version parameter (default to latest stable if not specified)
-RUST_VERSION="${1:-stable}"
+# Default versions
+DEFAULT_RUST_VERSION="1.74.0"
+DEFAULT_PYTHON_VERSION="3.10"
 
-# Python version parameter (default to 3.10 if not specified)
-PYTHON_VERSION="${2:-3.10}"
+# Initialize variables with default values
+RUST_VERSION="$DEFAULT_RUST_VERSION"
+PYTHON_VERSION="$DEFAULT_PYTHON_VERSION"
+
+# Function to display usage
+usage() {
+    echo "Usage: $0 [--rust <rust_version>] [--python <python_version>]"
+    exit 1
+}
+
+# Parse command-line options
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --rust) RUST_VERSION="$2"; shift ;;
+        --python) PYTHON_VERSION="$2"; shift ;;
+        *) usage ;;
+    esac
+    shift
+done
+
+# Rest of your setup script...
+echo "Setting up environment with Rust $RUST_VERSION and Python $PYTHON_VERSION"
 
 # Function to check if a command is available
 command_exists() {


### PR DESCRIPTION
- `setup.sh` is refactored to accept named arguments, such as rust version and python version, with `--rust <version>`, `--python <version>`.
- Both arguments are optional, if not provided the script uses the default values.
- Example usage : `./setup.sh --rust 1.55.0 --python 3.9`